### PR TITLE
Properly update display internals when updating bounds

### DIFF
--- a/lib/transitive.js
+++ b/lib/transitive.js
@@ -178,6 +178,8 @@ export default class Transitive {
     if (!this.display) return
     const smWestSouth = sm.forward(llBounds[0])
     const smEastNorth = sm.forward(llBounds[1])
+    // reset the display to make sure the correct display scale is recomputed
+    // see https://github.com/conveyal/transitive.js/pull/50
     this.display.reset()
     this.display.setXDomain([smWestSouth[0], smEastNorth[0]])
     this.display.setYDomain([smWestSouth[1], smEastNorth[1]])

--- a/lib/transitive.js
+++ b/lib/transitive.js
@@ -178,6 +178,7 @@ export default class Transitive {
     if (!this.display) return
     const smWestSouth = sm.forward(llBounds[0])
     const smEastNorth = sm.forward(llBounds[1])
+    this.display.reset()
     this.display.setXDomain([smWestSouth[0], smEastNorth[0]])
     this.display.setYDomain([smWestSouth[1], smEastNorth[1]])
     this.display.computeScale()


### PR DESCRIPTION
Some internals in the display class weren't properly getting updated when the map bounds were being changed. This was causing crazy-looking paths being drawn in certain cases.

Fixes https://github.com/opentripplanner/otp-react-redux/issues/159