### PR TITLE
Fix missing label rendering + label colors

### DIFF
--- a/cpbuild.sh
+++ b/cpbuild.sh
@@ -1,0 +1,5 @@
+echo 'rebuilding..'
+yarn prepublish
+echo 'copying built js..'
+cp -r ./build ~/git/otp-react-redux/node_modules/transitive-js
+echo 'done'

--- a/lib/core/route.js
+++ b/lib/core/route.js
@@ -1,3 +1,5 @@
+import {invertColor} from '../util/color'
+
 /**
  * A transit Route, as defined in the input data.
  * Routes contain one or more Patterns.
@@ -22,6 +24,15 @@ export default class Route {
   addPattern (pattern) {
     this.patterns.push(pattern)
     pattern.route = this
+  }
+
+  /**
+   * Rather than rely on the route text color field to be defined, simply return
+   * the black or white inverse of the background color.
+   */
+  getTextColor () {
+    const bgColor = this.getColor()
+    if (bgColor) return invertColor(bgColor)
   }
 
   getColor () {

--- a/lib/graph/edge.js
+++ b/lib/graph/edge.js
@@ -457,6 +457,10 @@ export default class Edge {
     return coords
   }
 
+  /**
+   * Get render coords for the provided offsets (0 values for offsets imply base
+   * render coordinates).
+   */
   getRenderCoords (fromOffsetPx, toOffsetPx, display, forward) {
     var isBase = (fromOffsetPx === 0 && toOffsetPx === 0)
 
@@ -627,81 +631,84 @@ export default class Edge {
    * @param {Display} display
    * @returns {Object} - the coordinate as an {x,y} Object
    */
-
-  // TODO: not working for geographically-rendered edges?
   coordAlongEdge (t, coords, display) {
     if (!this.baseRenderCoords) {
       this.calculateBaseRenderCoords(display)
     }
 
     if (coords.length !== this.baseRenderCoords.length) {
+      // If the render edge coordinates do not match the base render coordinates,
+      // get coordinate along "offset edge."
       return this.coordAlongOffsetEdge(t, coords, display)
     }
 
     // get the length of this edge in screen units using the "base" (i.e. un-offset) render coords
     var len = this.getRenderLength()
-
-    var loc = t * len // the target distance along the Edge's base geometry
-    var cur = 0 // our current location along the edge (in world units)
-
-    for (var i = 1; i < this.baseRenderCoords.length; i++) {
-      if (loc < cur + this.baseRenderCoords[i].len) {
-        var t2 = (loc - cur) / this.baseRenderCoords[i].len
-
-        if (coords[i].arc) {
-          var r = coords[i].radius
-          var theta = Math.PI * coords[i].arc / 180
-          var isCcw = ccw(coords[0].x, coords[0].y, coords[1].x, coords[1].y,
-            coords[2].x, coords[2].y)
-
-          return pointAlongArc(coords[1].x, coords[1].y, coords[2].x, coords[2].y, r, theta, isCcw, t2)
-        } else {
-          var dx = coords[i].x - coords[i - 1].x
-          var dy = coords[i].y - coords[i - 1].y
-
-          return {
-            x: coords[i - 1].x + dx * t2,
-            y: coords[i - 1].y + dy * t2
-          }
-        }
-      }
-      cur += this.baseRenderCoords[i].len
-    }
+    // the target distance along the Edge's base geometry
+    var loc = t * len
+    return this.coordAlongRefEdge(loc, coords, this.baseRenderCoords)
   }
 
-  coordAlongOffsetEdge (t, coords, display) {
-    if (!this.baseRenderCoords) this.calculateBaseRenderCoords(display)
-
+  /**
+   * Get coordinate along "offset edge."
+   * @param {[type]} t - a value between 0 and 1 representing the location of the
+   *   point to be computed
+   * @param {Object[]} coords - the offset coordinates computed for this edge.
+   * @returns {Object} - the coordinate as an {x,y} Object
+   */
+  coordAlongOffsetEdge (t, coords) {
+    // Get total length of edge by summing inter-coordinate distances.
     var len = 0
     for (var i = 1; i < coords.length; i++) {
-      len += coords[i].len
+      const c0 = coords[i - 1]
+      const c = coords[i]
+      if (!c.len) {
+        // If length between coord not available, calculate.
+        c.len = distance(c0.x, c0.y, c.x, c.y)
+      }
+      len += c.len
     }
+    // the target distance along the Edge's base geometry
+    var loc = t * len
+    return this.coordAlongRefEdge(loc, coords)
+  }
 
-    var loc = t * len // the target distance along the Edge's base geometry
-    var cur = 0 // our current location along the edge (in world units)
-
-    for (i = 1; i < coords.length; i++) {
-      if (loc < cur + coords[i].len) {
-        var t2 = (loc - cur) / coords[i].len
-
-        if (coords[i].arc) { // arc segment
-          var r = coords[i].radius
-          var theta = Math.PI * coords[i].arc / 180
-          var isCcw = ccw(coords[0].x, coords[0].y, coords[1].x, coords[1].y,
-            coords[2].x, coords[2].y)
-
-          return pointAlongArc(coords[1].x, coords[1].y, coords[2].x, coords[2].y, r, theta, isCcw, t2)
-        } else { // straight segment
-          var dx = coords[i].x - coords[i - 1].x
-          var dy = coords[i].y - coords[i - 1].y
-
+  /**
+   * Iterate over reference coordinates (which default to input coords) to find
+   * the coordinate along the edge at distance along edge.
+   * @param  {[type]} targetDistance - target distance along edge's base geometry
+   * @param  {[type]} coords - coordinates for edge
+   * @param  {[type]} [refCoordinates=coords] - reference coordinates to use for
+   *                                            distance. Defaults to coords.
+   * @returns {Object} - the coordinate as an {x,y} Object
+   */
+  coordAlongRefEdge (targetDistance, coords, refCoordinates = coords) {
+    // our current location along the edge (in world units)
+    let currentLocation = 0
+    for (var i = 1; i < refCoordinates.length; i++) {
+      const distanceToNextCoord = refCoordinates[i].len
+      const {arc, radius, x, y} = coords[i]
+      if (targetDistance < currentLocation + distanceToNextCoord) {
+        // Location falls within the previous and next coordinates. Calculate
+        // percentage along segment.
+        const percentAlong = (targetDistance - currentLocation) / distanceToNextCoord
+        if (arc) {
+          // Generate coordinate on arc segment
+          const theta = Math.PI * arc / 180
+          const [c0, c1, c2] = coords
+          const isCcw = ccw(c0.x, c0.y, c1.x, c1.y, c2.x, c2.y)
+          return pointAlongArc(c1.x, c1.y, c2.x, c2.y, radius, theta, isCcw, percentAlong)
+        } else {
+          // Generate coordinate on straight segment
+          const dx = x - coords[i - 1].x
+          const dy = y - coords[i - 1].y
           return {
-            x: coords[i - 1].x + dx * t2,
-            y: coords[i - 1].y + dy * t2
+            x: coords[i - 1].x + dx * percentAlong,
+            y: coords[i - 1].y + dy * percentAlong
           }
         }
       }
-      cur += coords[i].len
+      currentLocation += distanceToNextCoord
     }
   }
 

--- a/lib/labeler/labeledgegroup.js
+++ b/lib/labeler/labeledgegroup.js
@@ -24,39 +24,64 @@ export default class LabelEdgeGroup {
     return textArray
   }
 
+  /**
+   * Find the potential anchors for a label given a display and spacing.
+   * @param  {Display} display
+   * @param  {Number} spacing - spacing needed for label placement (i.e., label
+   *                            height with buffer)
+   */
   getLabelAnchors (display, spacing) {
     var labelAnchors = []
     var renderLen = this.getRenderLength(display)
+    // Determine how many anchors might fit along length.
     var anchorCount = Math.floor(renderLen / spacing)
     var pctSpacing = spacing / renderLen
 
     for (var i = 0; i < anchorCount; i++) {
-      var t = (i % 2 === 0)
+      // Calculate potential position of anchor.
+      const t = (i % 2 === 0)
         ? 0.5 + (i / 2) * pctSpacing
         : 0.5 - ((i + 1) / 2) * pctSpacing
-      var coord = this.coordAlongRenderedPath(t, display)
+      // Attempt to find coordinate along path for potential anchor.
+      const coord = this.coordAlongRenderedPath(t, display)
       if (coord) labelAnchors.push(coord)
     }
 
     return labelAnchors
   }
 
+  /**
+   * Get the coordinate located at a defined percentage along along a rendered path.
+   * @param {Number} t - a value between 0 and 1 representing the location of the
+   *   point to be computed
+   * @param {Display} display
+   * @returns {Object} - the coordinate as an {x,y} Object
+   */
   coordAlongRenderedPath (t, display) {
     var renderLen = this.getRenderLength(display)
+    // Get location along path.
     var loc = t * renderLen
 
+    // Iterate over each edge in path, accumulating distance as we go.
     var cur = 0
     for (var i = 0; i < this.renderedEdges.length; i++) {
       var rEdge = this.renderedEdges[i]
       var edgeRenderLen = rEdge.graphEdge.getRenderLength(display)
       if (loc <= cur + edgeRenderLen) {
+        // If location is along this edge, find and return the position along
+        // the edge.
         var t2 = (loc - cur) / edgeRenderLen
-        return rEdge.graphEdge.coordAlongEdge(t2, rEdge.renderData, display)
+        const coord = rEdge.graphEdge.coordAlongEdge(t2, rEdge.renderData, display)
+        return coord
       }
       cur += edgeRenderLen
     }
   }
 
+  /**
+   * Get the total render length for the edge group, which consists of the sum
+   * of each graph edge length.
+   */
   getRenderLength (display) {
     if (!this.renderLength) {
       this.renderLength = 0

--- a/lib/labeler/labeler.js
+++ b/lib/labeler/labeler.js
@@ -260,35 +260,33 @@ export default class Labeler {
     // iterate through the sequence collection, labeling as necessary
     forEach(edgeGroups, edgeGroup => {
       this.currentGroup = edgeGroup
-      // get the array of label strings to be places (typically the unique route short names)
+      // get the array of label strings to be places (typically the unique
+      // route short names)
       this.labelTextArray = edgeGroup.getLabelTextArray()
-
       // create the initial label for placement
       this.labelTextIndex = 0
 
-      var label = this.getNextLabel() // this.constructSegmentLabel(rSegment, labelTextArray[labelTextIndex]);
+      var label = this.getNextLabel()
       if (!label) return
-
-      // iterate through potential anchor locations, attempting placement at each one
-      var labelAnchors = edgeGroup.getLabelAnchors(this.transitive.display,
-        label.textHeight * 1.5)
+      // Iterate through potential anchor locations, attempting placement at
+      // each one
+      var labelAnchors = edgeGroup.getLabelAnchors(
+        this.transitive.display,
+        label.textHeight * 1.5
+      )
       for (var i = 0; i < labelAnchors.length; i++) {
         label.labelAnchor = labelAnchors[i]
-
+        const {x, y} = label.labelAnchor
         // do not consider this anchor if it is out of the display range
-        if (!this.transitive.display.isInRange(label.labelAnchor.x,
-          label.labelAnchor.y)) continue
-
+        if (!this.transitive.display.isInRange(x, y)) continue
         // check for conflicts with existing placed elements
-        var bbox = label.getBBox()
-        var conflicts = this.findOverlaps(label, bbox)
+        var conflicts = this.findOverlaps(label, label.getBBox())
 
-        if (conflicts.length === 0) { // if no conflicts
-          // place the current label
+        if (conflicts.length === 0) {
+          // If no overlaps/conflicts encountered, place the current label.
           placedLabels.push(label)
-          this.quadtree.add([label.labelAnchor.x, label.labelAnchor.y,
-            label
-          ])
+          // Track new label in quadtree.
+          this.quadtree.add([x, y, label])
           label = this.getNextLabel()
           if (!label) break
         }
@@ -335,6 +333,7 @@ export default class Labeler {
   }
 
   findOverlaps (label, labelBBox) {
+    // Get bounding box to check.
     var minX = labelBBox.x - this.maxBBoxWidth / 2
     var minY = labelBBox.y - this.maxBBoxHeight / 2
     var maxX = labelBBox.x + labelBBox.width + this.maxBBoxWidth / 2
@@ -342,11 +341,23 @@ export default class Labeler {
     // debug('findOverlaps %s,%s %s,%s', minX,minY,maxX,maxY);
 
     var matchItems = []
+    // Check quadtree for potential collisions.
     this.quadtree.visit((node, x1, y1, x2, y2) => {
-      var p = node.point
-      if ((p) && (p[0] >= minX) && (p[0] < maxX) && (p[1] >= minY) && (p[1] < maxY) && label.intersects(p[2])) {
-        matchItems.push(p[2])
+      const {point} = node
+      if (point) {
+        const [pX, pY, pLabel] = point
+        if (
+          pX >= minX &&
+          pX < maxX &&
+          pY >= minY &&
+          pY < maxY &&
+          label.intersects(pLabel)
+        ) {
+          matchItems.push(pLabel)
+        }
       }
+      // No need to visit children of this node if bbox falls entirely within
+      // this node.
       return x1 > maxX || y1 > maxY || x2 < minX || y2 < minY
     })
     return matchItems

--- a/lib/labeler/segmentlabel.js
+++ b/lib/labeler/segmentlabel.js
@@ -11,21 +11,27 @@ export default class SegmentLabel extends Label {
   }
 
   render (display) {
+    const x = this.labelAnchor.x - this.containerWidth / 2
+    const y = this.labelAnchor.y - this.containerHeight / 2
+    // Draw rounded rectangle for label.
     display.drawRect({
-      x: this.labelAnchor.x - this.containerWidth / 2,
-      y: this.labelAnchor.y - this.containerHeight / 2
+      x,
+      y
     }, {
+      // background color
       fill: display.styler.compute2('segment_labels', 'background', this.parent),
       width: this.containerWidth,
       height: this.containerHeight,
       rx: this.containerHeight / 2,
       ry: this.containerHeight / 2
     })
-
+    // Offset text location by padding
     display.drawText(this.getText(), {
-      x: this.labelAnchor.x - this.containerWidth / 2 + this.getPadding(),
-      y: this.labelAnchor.y - this.containerHeight / 2 + this.getPadding()
+      x: x + this.getPadding(),
+      // Offset y by a couple of pixels to account for off-centeredness.
+      y: y + this.getPadding() + 2
     }, {
+      // text color
       fill: display.styler.compute2('segment_labels', 'color', this.parent),
       'font-size': this.fontSize
     })

--- a/lib/renderer/renderededge.js
+++ b/lib/renderer/renderededge.js
@@ -77,6 +77,7 @@ export default class RenderedEdge {
   }
 
   offsetAlignment (alignmentId, offset) {
+    // If from/to alignment IDs match, set respective offset.
     if (this.graphEdge.getFromAlignmentId() === alignmentId) {
       this.setFromOffset(isOutwardVector(this.graphEdge.fromVector)
         ? offset
@@ -106,8 +107,7 @@ export default class RenderedEdge {
     if (this.useGeographicRendering && this.graphEdge.geomCoords) {
       this.renderData = this.graphEdge.getGeometricCoords(fromOffsetPx, toOffsetPx, display, this.forward)
     } else {
-      this.renderData = this.graphEdge.getRenderCoords(fromOffsetPx, toOffsetPx,
-        display, this.forward)
+      this.renderData = this.graphEdge.getRenderCoords(fromOffsetPx, toOffsetPx, display, this.forward)
     }
 
     var firstRenderPoint = this.renderData[0]

--- a/lib/styler/styles.js
+++ b/lib/styler/styles.js
@@ -205,8 +205,28 @@ const labels = {
 const segmentLabels = {
   'font-size': 15,
   'font-family': 'sans-serif',
-  color: '#fff',
-  background: '#008'
+  color: [
+    '#fff', // Text color falls back on white.
+    function (display, segment) {
+      if (segment.type === 'TRANSIT') {
+        if (segment.patterns) {
+          if (patternIsDcCirculatorBusRoute(segment.patterns[0])) return '#fff'
+          return segment.patterns[0].route.getTextColor()
+        }
+      }
+    }
+  ],
+  background: [
+    '#008', // Background color falls back on dark blue.
+    function (display, segment) {
+      if (segment.type === 'TRANSIT') {
+        if (segment.patterns) {
+          if (patternIsDcCirculatorBusRoute(segment.patterns[0])) return '#f00'
+          return segment.patterns[0].route.getColor()
+        }
+      }
+    }
+  ]
 }
 
 /**
@@ -216,7 +236,7 @@ const segmentLabels = {
 
 const segments = {
   stroke: [
-    '#008',
+    '#008', // Dark blue
     function (display, segment) {
       if (!segment.focused) return notFocusedColor
       if (segment.type === 'TRANSIT') {

--- a/lib/util/color.js
+++ b/lib/util/color.js
@@ -1,0 +1,39 @@
+/**
+ * For a provided hex color, returns an inverted color for legibility.
+ * @param  {[type]} hex - hexadecimal (HTML) color, e.g. #FFFFFF
+ * @param  {[type]} bw  - whether to return only black or white as inverted color
+ * @return {[type]}     [description]
+ */
+export function invertColor (hex, bw = true) {
+  if (hex.indexOf('#') === 0) {
+    hex = hex.slice(1)
+  }
+  // convert 3-digit hex to 6-digits.
+  if (hex.length === 3) {
+    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2]
+  }
+  if (hex.length !== 6) {
+    console.warn('Invalid HEX color.', hex)
+  }
+  let r = parseInt(hex.slice(0, 2), 16)
+  let g = parseInt(hex.slice(2, 4), 16)
+  let b = parseInt(hex.slice(4, 6), 16)
+  if (bw) {
+    // http://stackoverflow.com/a/3943023/112731
+    return (r * 0.299 + g * 0.587 + b * 0.114) > 186
+      ? '#000000'
+      : '#FFFFFF'
+  }
+  // invert color components
+  r = (255 - r).toString(16)
+  g = (255 - g).toString(16)
+  b = (255 - b).toString(16)
+  // pad each with zeros and return
+  return '#' + padZero(r) + padZero(g) + padZero(b)
+}
+
+export function padZero (str, len) {
+  len = len || 2
+  var zeros = new Array(len).join('0')
+  return (zeros + str).slice(-len)
+}

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -4,11 +4,10 @@
 
 import SphericalMercator from 'sphericalmercator'
 
-var tolerance = 0.000001
+const TOLERANCE = 0.000001
 
-function fuzzyEquals (a, b, tol) {
-  tol = tol || tolerance
-  return Math.abs(a - b) < tol
+function fuzzyEquals (a, b, tolerance = TOLERANCE) {
+  return Math.abs(a - b) < tolerance
 }
 
 function distance (x1, y1, x2, y2) {
@@ -84,7 +83,7 @@ function rayIntersection (ax, ay, avx, avy, bx, by, bvx, bvy) {
   return {
     u: u,
     v: v,
-    intersect: (u > -tolerance && v > -tolerance)
+    intersect: (u > -TOLERANCE && v > -TOLERANCE)
   }
 }
 
@@ -109,15 +108,18 @@ function lineIntersection (x1, y1, x2, y2, x3, y3, x4, y4) {
  *
  * @param {String/Number}
  */
-
 function parsePixelStyle (descriptor) {
   if (typeof descriptor === 'number') return descriptor
   return parseFloat(descriptor.substring(0, descriptor.length - 2), 10)
 }
 
+/**
+ * Whether vector is projected into positive xy quadrant.
+ */
 function isOutwardVector (vector) {
-  if (!fuzzyEquals(vector.x, 0)) return (vector.x > 0)
-  return (vector.y > 0)
+  return !fuzzyEquals(vector.x, 0)
+    ? vector.x > 0
+    : vector.y > 0
 }
 
 /**


### PR DESCRIPTION
This PR fixes #52 and #53. It also contains a number of additions to jsdoc, commenting, improved variable names, etc. that were applied while trying to figure out the underlying issue causing #53.

To test:
- run `yarn start` in otp-rr with (e.g.) CommTrans config.yml
- Visit [this test URL](http://localhost:9966/#/?ui_activeSearch=cwlyhu613&ui_activeItinerary=0&fromPlace=47.62005%2C%20-122.50707%3A%3A47.62004976487244%2C-122.50707207121154&toPlace=47.90668%2C%20-122.24353%3A%3A47.90667693563599%2C-122.24352820147304&date=2020-06-18&time=16%3A43&arriveBy=false&mode=WALK%2CBUS%2CTRAM%2CFERRY&showIntermediateStops=true&maxWalkDistance=1207&optimize=QUICK&walkSpeed=1.34&ignoreRealtimeUpdates=true&companies=) (do not reload -- keep for comparison for later)
- checkout this transitive branch and run `cpbuild.sh` to copy transpiled code into otp-rr
- Visit same [test URL](http://localhost:9966/#/?ui_activeSearch=cwlyhu613&ui_activeItinerary=0&fromPlace=47.62005%2C%20-122.50707%3A%3A47.62004976487244%2C-122.50707207121154&toPlace=47.90668%2C%20-122.24353%3A%3A47.90667693563599%2C-122.24352820147304&date=2020-06-18&time=16%3A43&arriveBy=false&mode=WALK%2CBUS%2CTRAM%2CFERRY&showIntermediateStops=true&maxWalkDistance=1207&optimize=QUICK&walkSpeed=1.34&ignoreRealtimeUpdates=true&companies=) in new tab.
- Compare the two. Code with fixes should show routes with labels that did not have them before and the label color should match the color that the route segment is rendered in. For example:

![image](https://user-images.githubusercontent.com/2370911/85155208-7898c280-b226-11ea-8640-cb10c92ba306.png)
