### PR TITLE
fix(label): handle missing getName function

### DIFF
--- a/lib/labeler/label.js
+++ b/lib/labeler/label.js
@@ -14,7 +14,11 @@ export default class Label {
   }
 
   initText () {
-    return this.parent.getName()
+    // TODO: determine why getName is missing for patterns running on routes
+    // without short names
+    return typeof this.parent.getName === 'function'
+      ? this.parent.getName()
+      : null
   }
 
   render (display) {}

--- a/lib/labeler/segmentlabel.js
+++ b/lib/labeler/segmentlabel.js
@@ -11,6 +11,9 @@ export default class SegmentLabel extends Label {
   }
 
   render (display) {
+    const text = this.getText()
+    // Do not attempt to render label if there is no label text.
+    if (!text) return null
     const x = this.labelAnchor.x - this.containerWidth / 2
     const y = this.labelAnchor.y - this.containerHeight / 2
     // Draw rounded rectangle for label.
@@ -26,7 +29,7 @@ export default class SegmentLabel extends Label {
       ry: this.containerHeight / 2
     })
     // Offset text location by padding
-    display.drawText(this.getText(), {
+    display.drawText(text, {
       x: x + this.getPadding(),
       // Offset y by a couple of pixels to account for off-centeredness.
       y: y + this.getPadding() + 2

--- a/lib/renderer/renderedsegment.js
+++ b/lib/renderer/renderedsegment.js
@@ -118,6 +118,8 @@ export default class RenderedSegment {
   getLabelTextArray () {
     var textArray = []
     forEach(this.patterns, pattern => {
+      // TODO: Should we attempt to extract part of the long name if short name
+      // is missing?
       var shortName = pattern.route.route_short_name
       if (textArray.indexOf(shortName) === -1) textArray.push(shortName)
     })


### PR DESCRIPTION
This PR fixes #55. 

Easiest way to test is to follow localhost instructions here from #55.
Then edit the files:
```
vi ~/git/trimet-mod-otp/node_modules/transitive-js/build/labeler/label.js
```
Replace line 36 (initText body) with:
```
return typeof this.parent.getName === 'function'
      ? this.parent.getName()
      : null
```
```
vi ~/git/trimet-mod-otp/node_modules/transitive-js/build/labeler/segmentlabel.js
```
Add to beginning of render function:
```
      var text = this.getText();
      if (!text) return null;
```