### PR TITLE
Show route labels for all routes and handle long names

### DIFF
--- a/lib/labeler/labeledgegroup.js
+++ b/lib/labeler/labeledgegroup.js
@@ -18,8 +18,10 @@ export default class LabelEdgeGroup {
   getLabelTextArray () {
     var textArray = []
     forEach(this.renderedSegment.pathSegment.getPatterns(), pattern => {
-      var shortName = pattern.route.route_short_name
-      if (textArray.indexOf(shortName) === -1) textArray.push(shortName)
+      textArray.push(
+        pattern.route.route_short_name ||
+          pattern.route.route_long_name
+      )
     })
     return textArray
   }

--- a/lib/labeler/labeler.js
+++ b/lib/labeler/labeler.js
@@ -251,7 +251,7 @@ export default class Labeler {
     var edgeGroups = []
     forEach(this.transitive.network.paths, path => {
       forEach(path.segments, segment => {
-        if (segment.type === 'TRANSIT' && segment.getMode() === 3) {
+        if (segment.type === 'TRANSIT') {
           edgeGroups = edgeGroups.concat(segment.getLabelEdgeGroups())
         }
       })


### PR DESCRIPTION
Currently, transitive only renders route labels for bus routes and crashes when there is no route_short_name for a bus route (#55). This PR makes transitive render a label for all transit routes and will use the route_long_name if the route_short_name doesn't exist.

This would fix #55.