### PR TITLE
Label bus routes by default if labeledModes not provided

### DIFF
--- a/lib/labeler/labeler.js
+++ b/lib/labeler/labeler.js
@@ -249,9 +249,11 @@ export default class Labeler {
       })
     })
 
-    // Generate labels for GTFS route/mode types listed in labeledModes.
+    // Generate labels for GTFS route/mode types listed in labeledModes if provided.
+    // If labeled modes is not provided, only label the buses (mode '3').
     var edgeGroups = []
-    const labeledModes = this.transitive.options.labeledModes
+    const busModes = [3]
+    const labeledModes = this.transitive.options.labeledModes || busModes
     forEach(this.transitive.network.paths, path => {
       forEach(path.segments, segment => {
         if (segment.type === 'TRANSIT' && labeledModes.includes(segment.getMode())) {


### PR DESCRIPTION
Fixes #69. 