### PR TITLE
Use actions GitHub token

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -29,7 +29,7 @@ jobs:
       # at this point, the build is successful
       - name: Semantic Release
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn semantic-release
 

--- a/lib/labeler/labeler.js
+++ b/lib/labeler/labeler.js
@@ -249,9 +249,11 @@ export default class Labeler {
       })
     })
 
-    // Generate labels for GTFS route/mode types listed in labeledModes.
+    // Generate labels for GTFS route/mode types listed in labeledModes if provided.
+    // If labeled modes is not provided, only label the buses (mode '3').
     var edgeGroups = []
-    const labeledModes = this.transitive.options.labeledModes
+    const busModes = [3]
+    const labeledModes = this.transitive.options.labeledModes || busModes
     forEach(this.transitive.network.paths, path => {
       forEach(path.segments, segment => {
         if (segment.type === 'TRANSIT' && labeledModes.includes(segment.getMode())) {


### PR DESCRIPTION
Instead of using someone's personal GitHub token, semantic-release will now use the GitHub token supplied in an actions workflow. cc @binh-dam-ibigroup.

This also merges #70 into dev.