### PR TITLE
Support OTP2 scooter modes

### DIFF
--- a/lib/styler/styler.js
+++ b/lib/styler/styler.js
@@ -142,7 +142,8 @@ export default class Styler {
       mode === 'CAR' ||
       mode === 'CAR_RENT' ||
       mode === 'MICROMOBILITY' ||
-      mode === 'MICROMOBILITY_RENT'
+      mode === 'MICROMOBILITY_RENT' ||
+      mode === 'SCOOTER' 
     ) {
       segment.type = mode
     } else {

--- a/lib/styler/styler.js
+++ b/lib/styler/styler.js
@@ -143,7 +143,7 @@ export default class Styler {
       mode === 'CAR_RENT' ||
       mode === 'MICROMOBILITY' ||
       mode === 'MICROMOBILITY_RENT' ||
-      mode === 'SCOOTER' 
+      mode === 'SCOOTER'
     ) {
       segment.type = mode
     } else {

--- a/lib/styler/styles.js
+++ b/lib/styler/styles.js
@@ -265,7 +265,7 @@ const segments = {
         return '#888'
       } else if (segment.type.startsWith('BICYCLE')) {
         return '#f00'
-      } else if (segment.type.startsWith('MICROMOBILITY')) {
+      } else if (segment.type.startsWith('MICROMOBILITY') || segment.type.startsWith('SCOOTER')) {
         return '#f5a729'
       } else if (segment.type === 'WALK') {
         return '#86cdf9'
@@ -280,7 +280,8 @@ const segments = {
       if (
         segment.type.startsWith('BICYCLE') ||
         segment.type.startsWith('CAR') ||
-        segment.type.startsWith('MICROMOBILITY')
+        segment.type.startsWith('MICROMOBILITY') ||
+        segment.type.startsWith('SCOOTER')
       ) {
         return '8, 3'
       }
@@ -303,6 +304,7 @@ const segments = {
       if (segment.type.startsWith('BICYCLE')) return 4
       if (segment.type.startsWith('CAR')) return 4
       if (segment.type.startsWith('MICROMOBILITY')) return 4
+      if (segment.type.startsWith('SCOOTER')) return 4
       if (segment.mode === 3) return 6 // Buses
     }
   ]

--- a/lib/styler/styles.js
+++ b/lib/styler/styles.js
@@ -265,7 +265,10 @@ const segments = {
         return '#888'
       } else if (segment.type.startsWith('BICYCLE')) {
         return '#f00'
-      } else if (segment.type.startsWith('MICROMOBILITY') || segment.type.startsWith('SCOOTER')) {
+      } else if (
+        segment.type.startsWith('MICROMOBILITY') ||
+        segment.type.startsWith('SCOOTER')
+      ) {
         return '#f5a729'
       } else if (segment.type === 'WALK') {
         return '#86cdf9'


### PR DESCRIPTION
OTP2, unlike OTP1, uses `SCOOTER` for E-Scooter rentals instead of `MICROMOBILITY_RENT`. This PR ensures that OTP2 scooter legs are rendered correctly, by adding `SCOOTER` everywhere where `MICROMOBILITY_RENT` is currently used.